### PR TITLE
Call setConnection() when creating the grammar

### DIFF
--- a/src/MysqlConnection.php
+++ b/src/MysqlConnection.php
@@ -29,7 +29,11 @@ class MysqlConnection extends IlluminateMySqlConnection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new MySqlGrammar);
+        $grammar = new MySqlGrammar;
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($this);
+        }
+        return $this->withTablePrefix($grammar);
     }
 
 


### PR DESCRIPTION
Hi,
With the new `toRawSql()`, `dumpRawSql()` and `ddRawSql()` added in Laravel 10.15 ([#47507](https://github.com/laravel/framework/pull/47507)), custom connections needs to call the method `setConnection()` when instantiating the query grammar.