### PR TITLE
Bump dependencies for Laravel 11 and PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=8.2",
         "ext-pdo": "*",
         "ext-json": "*",
         "illuminate/database": "^5.2|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
@@ -25,7 +25,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.8|~5.7|^9.5.10|^10.5",
         "mockery/mockery": "~1.3.0|^1.4.4",
-        "laravel/laravel": "^5.2|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "laravel/laravel": "^5.2|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "doctrine/dbal": "^2.5|^3.5",
         "laravel/browser-kit-testing": "^2.0|^6.4|^7.2",
         "php-coveralls/php-coveralls": "^2.0"


### PR DESCRIPTION
@lucabecchetti 

This pull request updates the dependency requirements to support Laravel 11 and PHP 8.2.
The code has been tested in my project and works as expected. I kindly request you to review and merge these changes into the main repository.

Thank you for considering this update!