### PR TITLE
bug fix for Call to a member function setTablePrefix() on null

### DIFF
--- a/src/MysqlConnection.php
+++ b/src/MysqlConnection.php
@@ -33,7 +33,7 @@ class MysqlConnection extends IlluminateMySqlConnection
         if (method_exists($grammar, 'setConnection')) {
             $grammar->setConnection($this);
         }
-        $this->setTablePrefix($this->tablePrefix);
+        $this->setQueryGrammar($grammar)->setTablePrefix($this->tablePrefix);
         return $grammar;
     }
 


### PR DESCRIPTION
After upgrade to 2.0.0
Any connection to MySQL goes to error "Call to a member function setTablePrefix() on null"

This pull request to fix this bug.